### PR TITLE
Script registration

### DIFF
--- a/solis_cmake_install/install_targets.cmake
+++ b/solis_cmake_install/install_targets.cmake
@@ -5,7 +5,7 @@
 # define in the project.
 # 
 # Author    Meltwin (github@meltwin.fr)
-# Date      19/10/2025 (created 18/10/2025)
+# Date      08/11/2025 (created 27/10/2025)
 # Version   1.0.0
 # Copyright Solis Forge | 2025 
 #           Distributed under MIT License (https://opensource.org/licenses/MIT)
@@ -89,5 +89,44 @@ function(_solis_install_python_modules)
         DESTINATION "${PROJECT_INSTALL_PYTHONDIR}/${_target}"
       )
     endforeach()
+  endif()
+endfunction()
+
+# =============================================================================
+# Export the project's scripts
+#
+# Author: Meltwin
+# Since : 1.0.0
+# =============================================================================
+function(_solis_install_scripts)
+  # Get all platform-independant scripts to install
+  get_solis_targets(_scripts SCRIPT)
+  list(LENGTH _scripts _length)
+  if (_length GREATER 0)
+    install(
+      PROGRAMS ${_scripts}
+      DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+  endif()
+
+  # Platform-depend scripts
+  if (WIN32)
+    get_solis_targets(_scripts SCRIPT_WIN)
+    list(LENGTH _scripts _length)
+    if (_length GREATER 0)
+      install(
+        PROGRAMS ${_scripts}
+        DESTINATION ${CMAKE_INSTALL_BINDIR}
+      )
+    endif()
+  else()
+    get_solis_targets(_scripts SCRIPT_LINUX)
+    list(LENGTH _scripts _length)
+    if (_length GREATER 0)
+      install(
+        PROGRAMS ${_scripts}
+        DESTINATION ${CMAKE_INSTALL_BINDIR}
+      )
+    endif()
   endif()
 endfunction()

--- a/solis_cmake_install/solis_cmake_install.cmake
+++ b/solis_cmake_install/solis_cmake_install.cmake
@@ -4,7 +4,7 @@
 # This file contains the include calls for all exporting solis projects.
 # 
 # Author    Meltwin (github@meltwin.fr)
-# Date      25/10/2025 (created 25/10/2025)
+# Date      08/11/2025 (created 27/10/2025)
 # Version   1.0.0
 # Copyright Solis Forge | 2025 
 #           Distributed under MIT License (https://opensource.org/licenses/MIT)
@@ -54,6 +54,7 @@ function(solis_install)
     _solis_install_cmake()
     _solis_install_cxx()
     _solis_install_python_modules()
+    _solis_install_scripts()
     # Make project's config file
     mk_solis_config()
     # Install environement

--- a/solis_cmake_targets/solis_cmake_targets.cmake
+++ b/solis_cmake_targets/solis_cmake_targets.cmake
@@ -4,7 +4,7 @@
 # Entry-point of the targets-related CMake module
 # 
 # Author    Meltwin (github@meltwin.fr)
-# Date      19/10/2025 (created 18/10/2025)
+# Date      08/11/2025 (created 19/10/2025)
 # Version   1.0.0
 # Copyright Solis Forge | 2025 
 #           Distributed under MIT License (https://opensource.org/licenses/MIT)
@@ -13,3 +13,4 @@
 include("${CMAKE_CURRENT_LIST_DIR}/targets_cmake.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/targets_cxx.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/targets_python.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/targets_scripts.cmake")

--- a/solis_cmake_targets/targets_python.cmake
+++ b/solis_cmake_targets/targets_python.cmake
@@ -1,10 +1,10 @@
 # =============================================================================
 # Project: SOLIS_CMAKE
 # 
-# 
+# Definition of Python module targets
 # 
 # Author    Meltwin (github@meltwin.fr)
-# Date      19/10/2025 (created 19/10/2025)
+# Date      08/11/2025 (created 19/10/2025)
 # Version   1.0.0
 # Copyright Solis Forge | 2025 
 #           Distributed under MIT License (https://opensource.org/licenses/MIT)

--- a/solis_cmake_targets/targets_scripts.cmake
+++ b/solis_cmake_targets/targets_scripts.cmake
@@ -1,0 +1,48 @@
+# =============================================================================
+# Project: SOLIS_CMAKE
+# 
+# Definition of script targets
+# 
+# Author    Meltwin (github@meltwin.fr)
+# Date      08/11/2025 (created 08/11/2025)
+# Version   1.0.0
+# Copyright Solis Forge | 2025 
+#           Distributed under MIT License (https://opensource.org/licenses/MIT)
+# =============================================================================
+
+# =============================================================================
+# Register a target to install a script in the bin directory
+#
+# Author: Meltwin
+# Since : 1.0.0
+# =============================================================================
+function(add_solis_script)
+    cmake_parse_arguments("" "WIN32;LINUX" "" "FILES;DIRECTORIES" ${ARGN})
+    get_files(script_files FILE ${_FILES} DIRECTORY ${_DIRECTORIES})
+
+    if (NOT "${script_files}" STREQUAL "")
+        # Register scripts
+        if (${_WIN32})
+            # Windows-only scripts
+            foreach(_script ${script_files})
+                log_step("Registering scripts \"${_script}\" (Windows only)")
+                register_solis_target(SCRIPT_WIN ${script_files})
+            endforeach()
+        elseif(${_LINUX})
+            # Linux-only scripts
+            foreach(_script ${script_files})
+                log_step("Registering scripts \"${_script}\" (Linux only)")
+                register_solis_target(SCRIPT_LINUX ${script_files})
+            endforeach()
+        else()
+            # All systems scripts (e.g. Python)
+            foreach(_script ${script_files})
+                log_step("Registering scripts \"${_script}\"")
+                register_solis_target(SCRIPT ${script_files})
+            endforeach()
+        endif()
+    else()
+        log_error("No scripts found in the given FILES and DIRECTORIES tags")
+    endif()   
+
+endfunction()

--- a/solis_cmake_utils/cache/targets.cmake
+++ b/solis_cmake_utils/cache/targets.cmake
@@ -5,7 +5,7 @@
 # targets.
 # 
 # Author    Meltwin (github@meltwin.fr)
-# Date      19/10/2025 (created 18/10/2025)
+# Date      08/11/2025 (created 19/10/2025)
 # Version   1.0.0
 # Copyright Solis Forge | 2025 
 #           Distributed under MIT License (https://opensource.org/licenses/MIT)
@@ -40,6 +40,7 @@ set(_SOLIS_TARGET_CACHES_TYPE
     "CMAKE" "CMAKE_NOLOAD" "CMAKE_MODULE" 
     "CXX_EXE" "CXX_LIB" 
     "PY_MODULE"
+    "SCRIPT" "SCRIPT_LINUX" "SCRIPT_WIN"
 )
 
 # =============================================================================
@@ -76,6 +77,12 @@ function(__get_solis_target_cache_doc _out _type)
         set(${_out} "C/C++ library targets to compile")
     elseif ("${_type}" STREQUAL "PY_MODULE")
         set(${_out} "C/C++ library targets to compile")
+    elseif ("${_type}" STREQUAL "SCRIPT")
+        set(${_out} "Platform-indepent scripts to install")
+    elseif ("${_type}" STREQUAL "SCRIPT_WIN")
+        set(${_out} "Windows scripts to install")
+    elseif ("${_type}" STREQUAL "SCRIPT_LINUX")
+        set(${_out} "Linux scripts to install")
     elseif("${_type}" IN_LIST _SOLIS_TARGET_CACHES_TYPE)
         set(${_out} "Unformated doc")
         log_warning("Documentation for target cache ${_type} is not written!")


### PR DESCRIPTION
Linked to #3 

Added a CMake function **add_solis_script** to register scripts and install them in the bin folder.

This function can accept two flags:
- WIN32: scripts specifically made for Windows
- LINUX: scripts specifically made for Linux

These flags controls which script to install at install time.